### PR TITLE
digコマンドを使ったDNS問い合わせで、srcIPがIPv4-mapped IPv6アドレスになってしまうバグを修正

### DIFF
--- a/gslb/corednsplugin/handler.go
+++ b/gslb/corednsplugin/handler.go
@@ -174,9 +174,14 @@ func (p *Gslb) A(ctx context.Context, qname, subdomain string, srcIP net.IP) ([]
 
 	// FIXME: we only act on "www.[domain]" for now.
 	if "www" == subdomain {
-		srcIP, ok := netip.AddrFromSlice(srcIP)
+		srcIPv4 := srcIP.To4()
+		if srcIPv4 == nil {
+			return nil, fmt.Errorf("(net.IP).To4(%v) failed.", srcIP)
+		}
+
+		srcIP, ok := netip.AddrFromSlice(srcIPv4)
 		if !ok {
-			return nil, fmt.Errorf("netip.AddrFromSlice(%v) failed.", srcIP)
+			return nil, fmt.Errorf("netip.AddrFromSlice(%v) failed.", srcIPv4)
 		}
 		ips := p.core.Query(srcIP)
 

--- a/gslb/corednsplugin/handler.go
+++ b/gslb/corednsplugin/handler.go
@@ -174,15 +174,12 @@ func (p *Gslb) A(ctx context.Context, qname, subdomain string, srcIP net.IP) ([]
 
 	// FIXME: we only act on "www.[domain]" for now.
 	if "www" == subdomain {
-		srcIPv4 := srcIP.To4()
-		if srcIPv4 == nil {
-			return nil, fmt.Errorf("(net.IP).To4(%v) failed.", srcIP)
-		}
-
-		srcIP, ok := netip.AddrFromSlice(srcIPv4)
+		srcIP, ok := netip.AddrFromSlice(srcIP)
 		if !ok {
-			return nil, fmt.Errorf("netip.AddrFromSlice(%v) failed.", srcIPv4)
+			return nil, fmt.Errorf("netip.AddrFromSlice(%v) failed.", srcIP)
 		}
+		srcIP = srcIP.Unmap()
+
 		ips := p.core.Query(srcIP)
 
 		for _, ip := range ips {


### PR DESCRIPTION
- digの方からDNSクエリを叩いたとき、srcIPが`::ffff:159.223.236.0`のようにIPv4-mappedなIPv6アドレスになる
  - これでは`(netip.Prefix).Contains`で引っかからないので、リージョン判定のアルゴリズムが書きにくい
- https://pkg.go.dev/net#IP.To4 を使って、IPv4部分のバイト列だけ取り出す実装とした
  - IPv4アドレスでない時は`nil`を返すので、念のためバリデーションも加えた

## 確認ログ
`dig www.ncdn.example @127.0.0.1 -p 10053 +subnet=159.223.236.0/32`の実行ログ

- 旧版
```
INFO Query srcIP=::ffff:159.223.236.0
[INFO] 127.0.0.1:45288 - 6661 "A IN www.ncdn.example. udp 57 false 1232" NOERROR qr,aa,rd 66 0.000232706s
```
- 修正版
```
INFO Query srcIP=159.223.236.0
[INFO] 127.0.0.1:58209 - 48466 "A IN www.ncdn.example. udp 57 false 1232" NOERROR qr,aa,rd 66 0.000221825s
```