### PR TITLE
特定の環境下でbrDevブリッジを介した通信が全て遮断される現象を解決

### DIFF
--- a/l4lb/netns_setup.sh
+++ b/l4lb/netns_setup.sh
@@ -55,6 +55,8 @@ function add_ns() {
 set -x
 ip l add name brDev type bridge
 ip l set dev brDev up
+# disable iptables in linux bridge
+sysctl -w net.bridge.bridge-nf-call-iptables=0
 
 add_ns_bare U # "198.51.100.200/24"
 add_ns R "192.168.88.1/24"


### PR DESCRIPTION
[参考資料](https://qiita.com/mochizuki875/items/c69bb7fb2ef3a73dc1a9#%E3%81%9D%E3%81%AE1bridge-netfilter%E3%82%92%E7%84%A1%E5%8A%B9%E5%8C%96%E3%81%99%E3%82%8B)

- `net.bridge.bridge-nf-call-iptables`が`1`になっている環境下でbrDevブリッジを介した通信が全て遮断されてしまうバグを解決するために、Linux BridgeのNetfilterがiptablesを参照しないようにする設定を加えた
- bridgeを使っているDockerには、後からパラメータを変えるだけでは影響が無かった
- WSL Ubuntu22.04環境では`net.bridge.bridge-nf-call-iptables`をコマンドで設定しても再起動すると`1`に戻るため、コマンドによる変更であれば持続的な影響は恐らく無いと思われる